### PR TITLE
feat(AI-7): relative json pointer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,32 @@ The extension must be linked to an image property using a [JSON pointer](https:/
 }
 ```
 
+If the caption extension is used inside a partial that is included in multiple content types, you can use a [relative JSON pointer](<https://json-schema.org/draft/2019-09/relative-json-pointer.html#:~:text=JSON%20Pointer%20(RFC%206901)%20is,locations%20from%20within%20the%20document.>) to define the image field.
+
+```json
+{
+  "image": {
+    "allOf": [
+      {
+        "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/image-link"
+      }
+    ]
+  },
+  "imageCaption": {
+    "title": "Hero Alt Text",
+    "type": "string",
+    "minLength": 0,
+    "maxLength": 200,
+    "ui:extension": {
+      "name": "ai-image-caption",
+      "params": {
+        "image": "1/image"
+      }
+    }
+  }
+}
+```
+
 ### Auto caption
 
 If enabled, the extension will automatically generate a caption when the image property is populated instead of requiring the user to manually press the caption button.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ You can configure the extension to load images from a different host using the `
 
 ```json
 {
-  "imageHost": "https://cdn.media.amplience.net"
+  "imageHost": "cdn.media.amplience.net"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@types/react": "^18.2.14",
     "@types/react-dom": "^18.2.6",
     "dc-extensions-sdk": "^2.2.0",
-    "json-pointer": "^0.6.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "5.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-extension-ai-image-caption",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "dependencies": {
     "@datadog/browser-rum": "^4.45.0",

--- a/src/components/CaptionExtension.stories.tsx
+++ b/src/components/CaptionExtension.stories.tsx
@@ -4,7 +4,14 @@ import { useState } from "react";
 import { ContentFieldExtensionContext } from "./WithFieldExtension";
 import { Box, Button } from "@mui/material";
 
-const Wrapper = ({ organizationId, initialValue, schema, params }) => {
+const Wrapper = ({
+  organizationId,
+  initialValue,
+  schema,
+  params,
+  formValue,
+  fieldPointer,
+}) => {
   const [value, setValue] = useState(initialValue || undefined);
   const [imageField, setImageField] = useState(undefined);
 
@@ -46,6 +53,7 @@ const Wrapper = ({ organizationId, initialValue, schema, params }) => {
     <ContentFieldExtensionContext.Provider
       value={
         {
+          fieldPointer,
           connection: {
             request: async (request, { vars }) => {
               await new Promise((resolve) =>
@@ -73,9 +81,12 @@ const Wrapper = ({ organizationId, initialValue, schema, params }) => {
             setValue: async (value: string) => {
               setValue(value);
             },
+            validate: (value) => {
+              return [{ pointer: fieldPointer }];
+            },
           },
           form: {},
-          formValue: {
+          formValue: formValue || {
             img: imageField,
             caption: value,
           },
@@ -228,5 +239,73 @@ export const AutoCaption: Story = {
     },
     organizationId: "org12345",
     initialValue: {},
+  },
+};
+
+export const WithRelativePointer: Story = {
+  args: {
+    schema: {
+      title: "Caption",
+      description: "Alt text",
+    },
+    params: {
+      installation: {
+        image: "3/img",
+      },
+    },
+    organizationId: "org12345",
+    initialValue: "saved value",
+    fieldPointer: "/seo/image/alt",
+    formValue: {
+      img: {
+        _meta: {
+          schema:
+            "http://bigcontent.io/cms/schema/v1/core#/definitions/image-link",
+        },
+        id: "338b8186-fa51-4427-8f43-edcc83b4763c",
+        name: "image1",
+        endpoint: "ampliencelabs",
+        defaultHost: "cdn.media.amplience.net",
+      },
+      seo: {
+        image: {
+          alt: "caption",
+        },
+      },
+    },
+  },
+};
+
+export const WithNestedRelativePointer: Story = {
+  args: {
+    schema: {
+      title: "Caption",
+      description: "Alt text",
+    },
+    params: {
+      installation: {
+        image: "2/src",
+      },
+    },
+    organizationId: "org12345",
+    initialValue: "saved value",
+    fieldPointer: "/image/seo/alt",
+    formValue: {
+      image: {
+        src: {
+          _meta: {
+            schema:
+              "http://bigcontent.io/cms/schema/v1/core#/definitions/image-link",
+          },
+          id: "338b8186-fa51-4427-8f43-edcc83b4763c",
+          name: "image1",
+          endpoint: "ampliencelabs",
+          defaultHost: "cdn.media.amplience.net",
+        },
+        seo: {
+          alt: "caption",
+        },
+      },
+    },
   },
 };

--- a/src/components/CaptionExtension.tsx
+++ b/src/components/CaptionExtension.tsx
@@ -130,7 +130,7 @@ function CaptionExtension() {
     } catch (err) {
       return undefined;
     }
-  }, [imagePointer, sdk.formValue, defaultHost]);
+  }, [imagePointer, sdk.formValue, sdk.fieldPointer, defaultHost]);
 
   const handleChange = (event) => {
     const newValue = event.target.value;

--- a/src/components/CaptionExtension.tsx
+++ b/src/components/CaptionExtension.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useReducer } from "react";
 import { useContentFieldExtension } from "./WithFieldExtension";
 import CaptionField from "./CaptionField";
-import pointer from "json-pointer";
+import RelativeJSONPointer from "../utils/RelativeJSONPointer";
 
 type SetInputValueReducerAction = {
   type: "SET_INPUT_VALUE";
@@ -109,7 +109,11 @@ function CaptionExtension() {
 
   const imageUrl = useMemo(() => {
     try {
-      const imageValue = pointer.get(sdk.formValue, imagePointer);
+      const imageValue = RelativeJSONPointer.evaluate(
+        imagePointer,
+        sdk.formValue,
+        sdk.fieldPointer
+      );
       if (
         !imageValue ||
         imageValue?._meta?.schema !==

--- a/src/utils/RelativeJSONPointer.ts
+++ b/src/utils/RelativeJSONPointer.ts
@@ -258,7 +258,7 @@ export function deletePointer<T = any>(
   return true;
 }
 
-export default {
+const exports = {
   escape,
   unescape,
   append,
@@ -271,3 +271,5 @@ export default {
   deletePointer,
   isValid,
 };
+
+export default exports;

--- a/src/utils/RelativeJSONPointer.ts
+++ b/src/utils/RelativeJSONPointer.ts
@@ -1,0 +1,273 @@
+export type ParsedPointer = [number, ...Array<string>] | string[];
+
+export class InvalidPointerError extends Error {
+  pointer: string;
+
+  constructor(pointer: string, message: string) {
+    super(message);
+    this.pointer = pointer;
+    Object.setPrototypeOf(this, InvalidPointerError.prototype);
+  }
+}
+
+/**
+ * Escapes a reference token
+ * @param value The JSON pointer token
+ */
+export function escape(value: string): string {
+  if (value === null || value === undefined || typeof value !== "string") {
+    return value;
+  }
+  return value.replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+/**
+ * Unescapes a reference token
+ * @param value Escaped JSON pointer token
+ */
+export function unescape(value: string): string {
+  if (value === null || value === undefined || typeof value !== "string") {
+    return value;
+  }
+  return value.replace(/~0/g, "~").replace(/~1/g, "/");
+}
+
+/**
+ * Appends reference tokens to a base JSON pointer.
+ * @param base JSON pointer to append tokens onto
+ * @param tokens Tokens to append to the JSON pointer
+ */
+export function append(base: string, tokens: string | string[]): string {
+  if (base === null || base === undefined || typeof base !== "string") {
+    return base;
+  }
+  if (
+    tokens === null ||
+    tokens === undefined ||
+    (typeof tokens !== "string" && !Array.isArray(tokens))
+  ) {
+    return base;
+  }
+
+  if (base.endsWith("/")) {
+    base = base.slice(0, base.length - 1);
+  }
+  tokens = Array.isArray(tokens) ? tokens : [tokens];
+  for (const token of tokens) {
+    base += "/" + escape(token);
+  }
+  return base;
+}
+
+/**
+ * Parse a JSON pointer string into an array of reference tokens
+ * @param pointer
+ */
+export function parse(pointer: string | undefined): ParsedPointer {
+  if (!pointer) {
+    return [];
+  }
+
+  if (pointer === "") {
+    return [];
+  }
+
+  if (/^\d+\/.*$/.test(pointer)) {
+    const [parentDepth, ...tokens] = pointer.split("/");
+    return [parseInt(parentDepth, 10), ...tokens.map(unescape)];
+  }
+
+  if (!pointer.startsWith("/")) {
+    throw new InvalidPointerError(pointer, "pointer must start with a /");
+  }
+
+  return pointer.slice(1).split("/").map(unescape);
+}
+
+export function isValid(pointer: any) {
+  if (
+    pointer === undefined ||
+    pointer === null ||
+    typeof pointer !== "string"
+  ) {
+    return false;
+  }
+
+  try {
+    parse(pointer);
+    return true;
+  } catch (err) {
+    if (err instanceof InvalidPointerError) {
+      return false;
+    }
+    throw err;
+  }
+}
+
+export function startsWith(pointer: string, searchPointer: string): boolean {
+  const pointerComponents = parse(pointer);
+  const searchComponents = parse(searchPointer);
+
+  // pointer must be longer than or equal to search length
+  if (pointerComponents.length < searchComponents.length) {
+    return false;
+  }
+
+  for (let i = 0; i < searchComponents.length; i++) {
+    if (pointerComponents[i] !== searchComponents[i]) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Computes a JSON pointer from a set of reference tokens
+ * @param tokens
+ */
+export function compile(tokens: ParsedPointer): string {
+  if (!Array.isArray(tokens)) {
+    return "";
+  }
+  if (tokens.length === 0) {
+    return "";
+  }
+  if (isRelativePointer(tokens)) {
+    return `${tokens[0]}/${tokens.map(escape).join("/")}`;
+  } else {
+    return "/" + tokens.map(escape).join("/");
+  }
+}
+
+/**
+ * Gets the parent pointer for the provided pointer
+ * @param pointer
+ * @returns
+ */
+export function parent(pointer: string): string | undefined {
+  if (pointer === "") {
+    return undefined;
+  }
+  const tokens = parse(pointer);
+  tokens.pop();
+  return compile(tokens);
+}
+
+export function isRelativePointer(
+  pointer: ParsedPointer
+): pointer is [number, ...Array<string>] {
+  return pointer.length > 0 && typeof pointer[0] === "number";
+}
+
+/**
+ * Evaluates the JSON pointer against the root document provided.
+ * @param pointer JSON pointer to evaluate
+ * @param root JSON document to evaluate the pointer against.
+ */
+export function evaluate(
+  pointer: string,
+  root: any,
+  startingPointer?: string
+): any | undefined {
+  let tokens = parse(pointer);
+  if (isRelativePointer(tokens)) {
+    if (!startingPointer) {
+      throw new InvalidPointerError(
+        pointer,
+        "pointer is relative but no starting pointer was provided"
+      );
+    }
+
+    const parentDepth = tokens[0];
+    let rootPointer = startingPointer;
+    for (let i = 0; i < parentDepth; i++) {
+      rootPointer = parent(rootPointer);
+    }
+
+    pointer = append(rootPointer, tokens.slice(1) as string[]);
+    tokens = parse(pointer);
+  }
+  let value = root;
+  for (const token of tokens) {
+    if (value && typeof value === "object") {
+      value = value && token in value ? value[token] : undefined;
+    } else {
+      break;
+    }
+  }
+  return value;
+}
+
+export function set<T = any>(
+  root: T,
+  targetPointer: string,
+  targetValue: any
+): T {
+  const tokens = parse(targetPointer);
+  if (tokens.length === 0) {
+    return targetValue as T;
+  }
+
+  let value: any = root;
+  while (tokens.length > 1) {
+    const token = tokens.shift() as string;
+    value =
+      value && typeof value === "object" && token in value
+        ? value[token]
+        : undefined;
+    if (!value) {
+      return root;
+    }
+  }
+
+  if (!value || typeof value !== "object") {
+    return root;
+  }
+
+  value[tokens[0]] = targetValue;
+  return root;
+}
+
+export function deletePointer<T = any>(
+  root: T,
+  targetPointer: string
+): boolean {
+  const tokens = parse(targetPointer);
+  if (tokens.length === 0) {
+    return false;
+  }
+
+  let value: any = root;
+  while (tokens.length > 1) {
+    const token = tokens.shift() as string;
+    value =
+      value && typeof value === "object" && token in value
+        ? value[token]
+        : undefined;
+    if (!value) {
+      return false;
+    }
+  }
+
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  delete value[tokens[0]];
+  return true;
+}
+
+export default {
+  escape,
+  unescape,
+  append,
+  parse,
+  parent,
+  compile,
+  evaluate,
+  set,
+  startsWith,
+  deletePointer,
+  isValid,
+};


### PR DESCRIPTION
This PR adds support for [relative json pointers](https://json-schema.org/draft/2019-09/relative-json-pointer.html#:~:text=JSON%20Pointer%20(RFC%206901)%20is,locations%20from%20within%20the%20document.) to allow the ai-image-caption extension to be used in partials that are subsequently included in other content types.

To use a relative pointer, the pointer must start with a number that represents how many parent levels to traverse up before using the rest of the pointer to traverse back down:

```json
{
  "image": {
    "allOf": [
      {
        "$ref": "http://bigcontent.io/cms/schema/v1/core#/definitions/image-link"
      }
    ]
  },
  "imageCaption": {
    "title": "Hero Alt Text",
    "type": "string",
    "minLength": 0,
    "maxLength": 200,
    "ui:extension": {
      "name": "ai-image-caption",
      "params": {
        "image": "1/image"
      }
    }
  }
}
```