### PR TITLE
fix: CMP-10500 Catch errors when setting an invalid value

### DIFF
--- a/src/components/CaptionExtension.tsx
+++ b/src/components/CaptionExtension.tsx
@@ -84,10 +84,7 @@ function CaptionExtension() {
   const sdk = useContentFieldExtension();
 
   const [{ inputValue, status }, dispatch] = useReducer(reducer, {
-    inputValue:
-      sdk.initialValue && typeof sdk.initialValue === "string"
-        ? sdk.initialValue
-        : "",
+    inputValue: sdk?.initialValue || "",
     status: "idle",
   });
 
@@ -135,7 +132,7 @@ function CaptionExtension() {
   const handleChange = (event) => {
     const newValue = event.target.value;
 
-    sdk.field.setValue(newValue);
+    sdk.field.setValue(newValue).catch(() => {});
     dispatch({ type: "SET_INPUT_VALUE", inputValue: newValue });
   };
 
@@ -161,7 +158,7 @@ function CaptionExtension() {
 
       if (data?.node?.generateCaptionForImage?.caption) {
         const caption = data.node.generateCaptionForImage?.caption;
-        sdk.field.setValue(caption);
+        sdk.field.setValue(caption).catch(() => {});
 
         dispatch({
           type: "COMPLETE_CAPTION",

--- a/src/components/StringField.tsx
+++ b/src/components/StringField.tsx
@@ -24,18 +24,10 @@ function StringField(props: StringFieldProps) {
   const label = schema?.title || "";
   const description = schema?.description || "";
 
-  const maxLength =
-    schema?.maxLength && typeof schema?.maxLength === "number"
-      ? schema?.maxLength
-      : undefined;
-
-  const minLength =
-    schema?.minLength && typeof schema?.minLength === "number"
-      ? schema?.minLength
-      : undefined;
-
+  const maxLength = schema?.maxLength;
+  const minLength = schema?.minLength;
   const pattern =
-    schema?.pattern && typeof schema?.pattern === "string"
+    typeof schema?.pattern === "string"
       ? new RegExp(schema?.pattern)
       : undefined;
 


### PR DESCRIPTION
- webpack was adding an iframe over the top of the control in dev mode when an error was thrown so catching the setValue call to prevent this. Also refactored some of the property checking to make it simpler