### PR TITLE
fix: CMP-10579 Remove error iframe

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10746,16 +10746,10 @@
       }
     },
     "node_modules/dc-extensions-sdk": {
-<<<<<<< HEAD
       "version": "2.2.0",
       "resolved": "git+ssh://git@github.com/amplience/dc-extensions-sdk.git#274f349726b44d77c55a710ae16d91a1e299761f",
       "integrity": "sha512-X42I9axTPyOX3QIbRvwG9nz0GkZjmJyiTGlH2l4uQLRMmTav/0/3UfEUQ4ozleVH3RyU465dm97+gcmPh+1wPQ==",
       "license": "MIT",
-=======
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/dc-extensions-sdk/-/dc-extensions-sdk-2.2.1.tgz",
-      "integrity": "sha512-V3evt+YbFTms/Dqx44/r0jJjbDzHDJt+nU4pm2MDgIOaT+5WF+nt7AiCGtM9Nxg+eLldvUraRdGEEy00pEI5AQ==",
->>>>>>> 3ca2e6a5e2ade0ee72a98dc1701616285e09fb1f
       "dependencies": {
         "message-event-channel": "^1.1.0"
       },

--- a/public/index.html
+++ b/public/index.html
@@ -10,6 +10,11 @@
       rel="stylesheet"
     />
     <title>dc-extension-ai-image-caption</title>
+    <style>
+      #webpack-dev-server-client-overlay {
+        pointer-events: none;
+      }
+    </style>
   </head>
 
   <body style="overflow: hidden">

--- a/src/components/CaptionExtension.tsx
+++ b/src/components/CaptionExtension.tsx
@@ -183,7 +183,7 @@ function CaptionExtension() {
         const isImage =
           imageValue?._meta?.schema ===
           "http://bigcontent.io/cms/schema/v1/core#/definitions/image-link";
-        const imageChanged = imageId !== imageValue.id;
+        const imageChanged = imageId !== imageValue?.id;
 
         if (isImage && imageChanged) {
           setImageId(imageValue.id);

--- a/src/components/CaptionField.tsx
+++ b/src/components/CaptionField.tsx
@@ -81,15 +81,17 @@ function CaptionField(props: CaptionFieldProps) {
                 className="buttonTooltip"
                 arrow
               >
-                <IconButton
-                  aria-label="generate caption"
-                  edge="end"
-                  color="primary"
-                  onClick={handleClick}
-                  disabled={captioningDisabled || readOnly}
-                >
-                  <SparkleIcon />
-                </IconButton>
+                <span>
+                  <IconButton
+                    aria-label="generate caption"
+                    edge="end"
+                    color="primary"
+                    onClick={handleClick}
+                    disabled={captioningDisabled || readOnly}
+                  >
+                    <SparkleIcon />
+                  </IconButton>
+                </span>
               </ButtonTooltip>
             )}
           </InputAdornment>

--- a/src/gainsight.ts
+++ b/src/gainsight.ts
@@ -1,6 +1,9 @@
 const aptrinsicId = process.env.REACT_APP_APTRINSIC_APP_ID;
 
 export function initGainsight() {
+  if (!aptrinsicId) {
+    return;
+  }
   window.aptrinsic = function () {
     (window.aptrinsic.q = window.aptrinsic.q || []).push(arguments);
   };


### PR DESCRIPTION
React adds an iframe over the top of the component whenver there is an error. This is annoying because it prevents the extension from working and can show for non-issues e.g. missing Gainsight ID. The style has been set to pointer-events: none so it doesn't block use of the extension