### PR TITLE
chore(readme): update readme to point to latest revision of relative json pointer spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The extension must be linked to an image property using a [JSON pointer](https:/
 }
 ```
 
-If the extension is used inside a partial that is included in multiple content types, you can use a [relative JSON pointer](<https://json-schema.org/draft/2019-09/relative-json-pointer.html#:~:text=JSON%20Pointer%20(RFC%206901)%20is,locations%20from%20within%20the%20document.>) to define the image field.
+If the extension is used inside a partial that is included in multiple content types, you can use a [relative JSON pointer](https://www.ietf.org/id/draft-hha-relative-json-pointer-00.html) to define the image field.
 
 ```json
 {


### PR DESCRIPTION
The link to the relative JSON pointer spec points to a page that no longer exists. This change updates the URL to point to the latest revision of the spec hosted by the IETF.